### PR TITLE
Added nonce to request so we can retry them

### DIFF
--- a/server/fixedhashset.go
+++ b/server/fixedhashset.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"bytes"
+	"sync"
+)
+
+type fixedHashSet struct {
+	shards [64]struct {
+		rLock  sync.RWMutex
+		wLock  sync.Mutex
+		offset int
+		hashes [1024][16]byte
+	}
+}
+
+// Contains returns true if hash is in the hashset
+func (s *fixedHashSet) Contains(hash []byte) bool {
+	// Find relevant shard
+	shard := &s.shards[(hash[0]^hash[1]^hash[2]^hash[3])%64]
+
+	// Aqcuire read lock
+	shard.rLock.Lock()
+	defer shard.rLock.Unlock()
+
+	// Check if the hash exists
+	for i := 0; i < 1024; i++ {
+		if bytes.Equal(shard.hashes[i][:], hash) {
+			return true
+		}
+	}
+	return false
+}
+
+// Insert hash
+func (s *fixedHashSet) Insert(hash []byte) {
+	// Find relevant shard
+	shard := &s.shards[(hash[0]^hash[1]^hash[2]^hash[3])%64]
+
+	// Acquire write lock (upgrading control)
+	shard.wLock.Lock()
+	defer shard.wLock.Unlock()
+
+	// Insert hash
+	copy(shard.hashes[shard.offset][:], hash)
+	shard.offset = (shard.offset + 1) % 1024
+}

--- a/server/server.go
+++ b/server/server.go
@@ -179,9 +179,9 @@ failed:
 }
 
 func (s *StatSum) parse(project string, w http.ResponseWriter, r *http.Request) {
-	// Check that the nonce is unique, so we can retry without duplication
-	nonce := uuid.Parse(r.Header.Get("X-Statsum-Nonce"))
-	if nonce != nil && s.hashSet.Contains(nonce) {
+	// Check that the request-id is unique, so we can retry without duplication
+	reqID := uuid.Parse(r.Header.Get("X-Statsum-Request-Id"))
+	if reqID != nil && s.hashSet.Contains(reqID) {
 		reply(w, http.StatusOK, payload.Response{
 			Code:    "PayloadAccepted",
 			Message: "Payload have already been aggregated before",
@@ -233,9 +233,9 @@ func (s *StatSum) parse(project string, w http.ResponseWriter, r *http.Request) 
 	// Aggregate data
 	s.process(project, &p)
 
-	// Insert nonce so we don't aggregate this twice
-	if nonce != nil {
-		s.hashSet.Insert(nonce)
+	// Insert reqID so we don't aggregate this twice
+	if reqID != nil {
+		s.hashSet.Insert(reqID)
 	}
 
 	// Send a response 200 OK reply

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jonasfj/statsum/payload"
+	"github.com/pborman/uuid"
 
 	"gopkg.in/dgrijalva/jwt-go.v2"
 )
@@ -28,15 +29,18 @@ func assert(condition bool, a ...interface{}) {
 	}
 }
 
-func doTestRequest(r *http.Request) *httptest.ResponseRecorder {
+func doTestRequest(r *http.Request, statsum *StatSum) (*httptest.ResponseRecorder, *StatSum) {
 	if r == nil {
 		panic("Failed to provide request, probably error in making it!")
 	}
-	statsum, err := New(Config{JwtSecret: []byte("secret")})
+	var err error
+	if statsum == nil {
+		statsum, err = New(Config{JwtSecret: []byte("secret")})
+	}
 	nilOrPanic(err)
 	w := httptest.NewRecorder()
 	statsum.handler(w, r)
-	return w
+	return w, statsum
 }
 
 var testBody = payload.Payload{
@@ -85,15 +89,113 @@ func TestHandleCorrectPrefix(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", auth("prefix"))
-	w := doTestRequest(r)
+	w, s := doTestRequest(r, nil)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	var testCount float64
+	var testMeasureMax float64
+	s.aggregator.SendMetrics(func(name string, value float64) {
+		if name == "prefix.test-count.5m.count" {
+			testCount = value
+		}
+		if name == "prefix.test-measure.5m.max" {
+			testMeasureMax = value
+		}
+	})
+	assert(testCount == 42, "Expected prefix.test-count.5m.count = 42")
+	assert(testMeasureMax == 9, "Expected prefix.test-measure.5m.max = 9")
+}
+
+func TestAggretation(t *testing.T) {
+	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", auth("prefix"))
+	w, s := doTestRequest(r, nil)
+	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	// Send another request
+	r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", auth("prefix"))
+	w, s = doTestRequest(r, s)
+	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	// Look at metrics
+	var testCount float64
+	var testMeasureMax float64
+	s.aggregator.SendMetrics(func(name string, value float64) {
+		if name == "prefix.test-count.5m.count" {
+			testCount = value
+		}
+		if name == "prefix.test-measure.5m.max" {
+			testMeasureMax = value
+		}
+	})
+	assert(testCount == 42*2, "Expected prefix.test-count.5m.count = 42*2")
+	assert(testMeasureMax == 9, "Expected prefix.test-measure.5m.max = 9")
+}
+
+func TestAggretationWithNonce(t *testing.T) {
+	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+	r.Header.Set("Authorization", auth("prefix"))
+	w, s := doTestRequest(r, nil)
+	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	// Send another request
+	r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+	r.Header.Set("Authorization", auth("prefix"))
+	w, s = doTestRequest(r, s)
+	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	// Look at metrics
+	var testCount float64
+	var testMeasureMax float64
+	s.aggregator.SendMetrics(func(name string, value float64) {
+		if name == "prefix.test-count.5m.count" {
+			testCount = value
+		}
+		if name == "prefix.test-measure.5m.max" {
+			testMeasureMax = value
+		}
+	})
+	assert(testCount == 42*2, "Expected prefix.test-count.5m.count = 42*2")
+	assert(testMeasureMax == 9, "Expected prefix.test-measure.5m.max = 9")
+}
+
+func TestAggretationWithRetries(t *testing.T) {
+	nonce := uuid.NewRandom().String()
+	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("X-Statsum-Nonce", nonce)
+	r.Header.Set("Authorization", auth("prefix"))
+	w, s := doTestRequest(r, nil)
+	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	// Send another request with same nonce
+	r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("X-Statsum-Nonce", nonce)
+	r.Header.Set("Authorization", auth("prefix"))
+	w, s = doTestRequest(r, s)
+	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
+	// Look at metrics
+	var testCount float64
+	var testMeasureMax float64
+	s.aggregator.SendMetrics(func(name string, value float64) {
+		if name == "prefix.test-count.5m.count" {
+			testCount = value
+		}
+		if name == "prefix.test-measure.5m.max" {
+			testMeasureMax = value
+		}
+	})
+	assert(testCount == 42, "Expected prefix.test-count.5m.count = 42")
+	assert(testMeasureMax == 9, "Expected prefix.test-measure.5m.max = 9")
 }
 
 func TestHandleCorrectPrefixSpecialChars(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/Pre-f_ix9", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
 	r.Header.Set("Authorization", auth("Pre-f_ix9"))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
 }
 
@@ -101,7 +203,7 @@ func TestHandleMsgPack(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", msgpBody(testBody))
 	r.Header.Set("Content-Type", "application/msgpack")
 	r.Header.Set("Authorization", auth("prefix"))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
 }
 
@@ -111,7 +213,7 @@ func TestHandleInvalidJSON(t *testing.T) {
   }`))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", auth("prefix"))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusBadRequest, "invalid json didn't fail")
 }
 
@@ -119,7 +221,7 @@ func TestHandleInvalidContentType(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
 	r.Header.Set("Content-Type", "something/wrong")
 	r.Header.Set("Authorization", auth("prefix"))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusUnsupportedMediaType, "invalid content-type didn't fail")
 }
 
@@ -127,7 +229,7 @@ func TestHandleInvalidPath(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/lala/lala", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", auth("lala/lala"))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusNotFound, "/lala/lala didn't fail")
 }
 
@@ -135,7 +237,7 @@ func TestHandleMissingPrefix(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", auth(""))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusNotFound, "/v1/project/ didn't fail")
 }
 
@@ -143,7 +245,7 @@ func TestHandleIllegalPrefix(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/d/d", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", auth("d/d"))
-	w := doTestRequest(r)
+	w, _ := doTestRequest(r, nil)
 	assert(w.Code == http.StatusBadRequest, "/v1/project/d/d didn't fail")
 }
 
@@ -244,6 +346,43 @@ func BenchmarkCounts(b *testing.B) {
 	})
 }
 
+func BenchmarkCountsWithNonce(b *testing.B) {
+	statsum, err := New(Config{JwtSecret: []byte("secret")})
+	nilOrPanic(err, "Failed to create statsum")
+	authorization := auth("p")
+	p1 := jsonBytes(pc1)
+	p2 := jsonBytes(pc2)
+	p3 := jsonBytes(pc3)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p1))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("Authorization", authorization)
+			w := httptest.NewRecorder()
+			statsum.handler(w, r)
+			assert(w.Code == http.StatusOK, "Failed to send request 1")
+
+			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p2))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("Authorization", authorization)
+			w = httptest.NewRecorder()
+			statsum.handler(w, r)
+			assert(w.Code == http.StatusOK, "Failed to send request 2")
+
+			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p3))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("Authorization", authorization)
+			w = httptest.NewRecorder()
+			statsum.handler(w, r)
+			assert(w.Code == http.StatusOK, "Failed to send request 3")
+		}
+	})
+}
+
 var pv1 = payload.Payload{
 	Measures: []payload.Measure{
 		{Key: "test-count-1", Value: []float64{1, 2, 3, 4, 5, 6, 7, 8, 10}},
@@ -298,6 +437,43 @@ func BenchmarkValues(b *testing.B) {
 
 			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p3))
 			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("Authorization", authorization)
+			w = httptest.NewRecorder()
+			statsum.handler(w, r)
+			assert(w.Code == http.StatusOK, "Failed to send request 3")
+		}
+	})
+}
+
+func BenchmarkValuesWithNonce(b *testing.B) {
+	statsum, err := New(Config{JwtSecret: []byte("secret")})
+	nilOrPanic(err, "Failed to create statsum")
+	authorization := auth("p")
+	p1 := jsonBytes(pv1)
+	p2 := jsonBytes(pv2)
+	p3 := jsonBytes(pv3)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p1))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("Authorization", authorization)
+			w := httptest.NewRecorder()
+			statsum.handler(w, r)
+			assert(w.Code == http.StatusOK, "Failed to send request 1")
+
+			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p2))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("Authorization", authorization)
+			w = httptest.NewRecorder()
+			statsum.handler(w, r)
+			assert(w.Code == http.StatusOK, "Failed to send request 2")
+
+			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p3))
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w = httptest.NewRecorder()
 			statsum.handler(w, r)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -132,17 +132,17 @@ func TestAggretation(t *testing.T) {
 	assert(testMeasureMax == 9, "Expected prefix.test-measure.5m.max = 9")
 }
 
-func TestAggretationWithNonce(t *testing.T) {
+func TestAggretationWithReqId(t *testing.T) {
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+	r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 	r.Header.Set("Authorization", auth("prefix"))
 	w, s := doTestRequest(r, nil)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
 	// Send another request
 	r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+	r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 	r.Header.Set("Authorization", auth("prefix"))
 	w, s = doTestRequest(r, s)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
@@ -162,17 +162,17 @@ func TestAggretationWithNonce(t *testing.T) {
 }
 
 func TestAggretationWithRetries(t *testing.T) {
-	nonce := uuid.NewRandom().String()
+	reqID := uuid.NewRandom().String()
 	r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("X-Statsum-Nonce", nonce)
+	r.Header.Set("X-Statsum-Request-Id", reqID)
 	r.Header.Set("Authorization", auth("prefix"))
 	w, s := doTestRequest(r, nil)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
-	// Send another request with same nonce
+	// Send another request with same Request-Id
 	r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/prefix", jsonBody(testBody))
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("X-Statsum-Nonce", nonce)
+	r.Header.Set("X-Statsum-Request-Id", reqID)
 	r.Header.Set("Authorization", auth("prefix"))
 	w, s = doTestRequest(r, s)
 	assert(w.Code == http.StatusOK, "/v1/project/prefix failed")
@@ -346,7 +346,7 @@ func BenchmarkCounts(b *testing.B) {
 	})
 }
 
-func BenchmarkCountsWithNonce(b *testing.B) {
+func BenchmarkCountsWithReqId(b *testing.B) {
 	statsum, err := New(Config{JwtSecret: []byte("secret")})
 	nilOrPanic(err, "Failed to create statsum")
 	authorization := auth("p")
@@ -358,7 +358,7 @@ func BenchmarkCountsWithNonce(b *testing.B) {
 		for pb.Next() {
 			r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p1))
 			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w := httptest.NewRecorder()
 			statsum.handler(w, r)
@@ -366,7 +366,7 @@ func BenchmarkCountsWithNonce(b *testing.B) {
 
 			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p2))
 			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w = httptest.NewRecorder()
 			statsum.handler(w, r)
@@ -374,7 +374,7 @@ func BenchmarkCountsWithNonce(b *testing.B) {
 
 			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p3))
 			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w = httptest.NewRecorder()
 			statsum.handler(w, r)
@@ -445,7 +445,7 @@ func BenchmarkValues(b *testing.B) {
 	})
 }
 
-func BenchmarkValuesWithNonce(b *testing.B) {
+func BenchmarkValuesWithReqId(b *testing.B) {
 	statsum, err := New(Config{JwtSecret: []byte("secret")})
 	nilOrPanic(err, "Failed to create statsum")
 	authorization := auth("p")
@@ -457,7 +457,7 @@ func BenchmarkValuesWithNonce(b *testing.B) {
 		for pb.Next() {
 			r, _ := http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p1))
 			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w := httptest.NewRecorder()
 			statsum.handler(w, r)
@@ -465,7 +465,7 @@ func BenchmarkValuesWithNonce(b *testing.B) {
 
 			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p2))
 			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w = httptest.NewRecorder()
 			statsum.handler(w, r)
@@ -473,7 +473,7 @@ func BenchmarkValuesWithNonce(b *testing.B) {
 
 			r, _ = http.NewRequest("POST", "https://statsum.local/v1/project/p", bytes.NewReader(p3))
 			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("X-Statsum-Nonce", uuid.NewRandom().String())
+			r.Header.Set("X-Statsum-Request-Id", uuid.NewRandom().String())
 			r.Header.Set("Authorization", authorization)
 			w = httptest.NewRecorder()
 			statsum.handler(w, r)


### PR DESCRIPTION
does this look sane...

maybe the implementation is crazy... :)

The point is that if statsum client generates a uuid each time it sends a request, it can safely retry the request, as long as we include the same uuid in the retry..

The numbers are just sort of guess work... I'm sure the data structure is particularly smart... But it's certainly simple... I suspect the byte scanning 4 pages == 16kb for each request isn't so bad..

benchmarks comparing nonce, vs. no nonce:
```go
BenchmarkCounts-4         	   50000	     27160 ns/op
BenchmarkCountsWithNonce-4	   50000	     38329 ns/op
BenchmarkValues-4         	   20000	     79866 ns/op
BenchmarkValuesWithNonce-4	   20000	     87347 ns/op
BenchmarkValuesMsgPack-4  	   20000	     63916 ns/op

```