### PR TITLE
Enable CI in pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -11,8 +11,7 @@ tasks:
       github:
         events:
           - push
-        branches:
-          - master
+          - pull_request.synchronize
     scopes:
       - auth:aws-s3:read-write:taskcluster-raw-docs/statsum/
     payload:


### PR DESCRIPTION
On reflection, maybe granting `auth:aws-s3:read-write:taskcluster-raw-docs/statsum/` to untrusted pull requests might be a bad idea... :-(

Not sure how paranoid to be!