### PR TITLE
Fix server memory consumption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-TAG := v12
+TAG := v13
 
 install:
 	go get github.com/pkg/errors

--- a/server/signalfx.go
+++ b/server/signalfx.go
@@ -55,6 +55,7 @@ func (s *signalfxDrain) Flush() error {
 	if err != nil {
 		panic(errors.Wrap(err, "failed to marshal payload to JSON"))
 	}
+
 	req.Header.Set("X-SF-Token", s.token)
 	res, err := req.Send()
 	if err != nil {
@@ -63,5 +64,8 @@ func (s *signalfxDrain) Flush() error {
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("Wrong status code from signalfx: %d", res.StatusCode)
 	}
+
+	s.points = []datapoint{} // release accumulated memory
+
 	return nil
 }


### PR DESCRIPTION
The signalfx drain accumulates data points in an array until the Flush
method is called. After that, the array should be reseted, but this was
not what was happening. Therefore, not only we the memory consumption
monotonically increase, but we also sent more and more amounts of data
to signalfx as the time passed.